### PR TITLE
Fix transcript generation bug with tag-like context

### DIFF
--- a/src/tsToArray.ts
+++ b/src/tsToArray.ts
@@ -5,8 +5,8 @@ export type ITranscriptLine = {
 }
 
 export default function parseTranscript(vtt: string): ITranscriptLine[] {
-  // 1. sepparate lines at timestamp's open bracket
-  const lines: string[] = vtt.split('[');
+  // 1. separate lines by matching the format like "[00:03:04.000 --> 00:03:13.000]   XXXXXX"
+  const lines: string[] = vtt.match(/\[[0-9:.]+\s-->\s[0-9:.]+\].*/g);
 
   // 2. remove the first line, which is empty
   lines.shift();
@@ -14,12 +14,15 @@ export default function parseTranscript(vtt: string): ITranscriptLine[] {
   // 3. convert each line into an object
   return lines.map(line => {
     // 3a. split ts from speech
-    let [timestamp, speech] = line.split(']  ');
+    let [timestamp, speech] = line.split(']   ');
     
-    // 3b. split timestamp into begin and end
+    // 3b. remove the open bracket of timestamp
+    timestamp = timestamp.substring(1);
+
+    // 3c. split timestamp into begin and end
     const [start, end] = timestamp.split(' --> ');
     
-    // 3c. remove \n from speech with regex
+    // 3d. remove \n from speech with regex
     speech = speech.replace(/\n/g, '');
 
     return { start, end, speech };


### PR DESCRIPTION
I hope this message finds you well. I came across a minor issue in the transcript regeneration process and have implemented a fix that I'd like to share with you.

Previously, the presence of tag-like context (e.g., [music]) in the video caused some inconsistencies during the transcript regeneration process. The root of this issue was the original method's splitting of strings based on the open bracket, which resulted in the tag-like context being divided into separate lines. Consequently, this led to errors when extracting timestamps and speech.

With the proposed changes in this commit, the method has been updated to handle tag-like context more effectively, preventing the aforementioned errors. I believe this improvement will enhance the overall functionality and user experience.

Please kindly review the changes, and feel free to provide any feedback or suggestions. I'd be more than happy to make further modifications if necessary.

Thank you for considering this contribution, and I look forward to hearing your thoughts.

The tag-like context ( [music] )
![bug](https://user-images.githubusercontent.com/44407466/233799124-9df0a5e9-dd1a-4b1d-8ef2-345270716991.png)

The result after change
![result](https://user-images.githubusercontent.com/44407466/233799538-fdd3fba2-7d9c-4230-b4bc-e45d7fb23857.png)
