### PR TITLE
Update index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,9 +21,9 @@ export const whisper = async (filePath: string, options?: IOptions): Promise<ITr
 
     // 1. create command string for whisper.cpp
     const command = createCppCommand({
-      filePath: path.normalize(filePath),
+      filePath: path.normalize(`"${filePath}"`),
       modelName: options?.modelName,
-      modelPath: options?.modelPath,
+      modelPath: options?.modelPath ? `"${options?.modelPath}"` : undefined,
       options: options?.whisperOptions
     })
 


### PR DESCRIPTION
Added doublequotes to filePath and modelPath, otherwise the whisper command would fail if path contain spaces.

./main command before:

`./main  -l auto -m /path/directory with space/ggml-large-v3.bin -f /path/directory with space/speech_test.wav`

./main command after:

`./main  -l auto -m "/path/directory with space/ggml-large-v3.bin" -f "/path/directory with space/speech_test.wav"`

Works on Mac – I have not tested on Windows.