### PR TITLE
[parse-transcript] fix: removing the first line is not necessary

### DIFF
--- a/src/tsToArray.ts
+++ b/src/tsToArray.ts
@@ -8,10 +8,7 @@ export default function parseTranscript(vtt: string): ITranscriptLine[] {
   // 1. separate lines by matching the format like "[00:03:04.000 --> 00:03:13.000]   XXXXXX"
   const lines: string[] = vtt.match(/\[[0-9:.]+\s-->\s[0-9:.]+\].*/g);
 
-  // 2. remove the first line, which is empty
-  lines.shift();
-
-  // 3. convert each line into an object
+  // 2. convert each line into an object
   return lines.map(line => {
     // 3a. split ts from speech
     let [timestamp, speech] = line.split(']  '); // two spaces (3 spaces doesn't work with punctuation like period . )
@@ -21,10 +18,10 @@ export default function parseTranscript(vtt: string): ITranscriptLine[] {
 
     // 3c. split timestamp into begin and end
     const [start, end] = timestamp.split(' --> ');
-    
+
     // 3d. remove \n from speech with regex
     speech = speech.replace(/\n/g, '');
-    
+
     // 3e. remove beginning space
     speech = speech.replace(' ', '');
 


### PR DESCRIPTION
Fixed a bug where transcriptions would start missing the first few words if the first line was removed. Now, the transcription starts from the very beginning, so nothing gets left out.