### PR TITLE
Adding output file path option present in whisper.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,16 @@ import whisper from 'whisper-node';
 const filePath = "example/sample.wav"; // required
 
 const options = {
-  modelName: "base.en",       // default
+  modelName: "base.en",               // default
   // modelPath: "/custom/path/to/model.bin", // use model in a custom directory (cannot use along with 'modelName')
   whisperOptions: {
-    language: 'auto'          // default (use 'auto' for auto detect)
-    gen_file_txt: false,      // outputs .txt file
-    gen_file_subtitle: false, // outputs .srt file
-    gen_file_vtt: false,      // outputs .vtt file
-    word_timestamps: true     // timestamp for every word
-    // timestamp_size: 0      // cannot use along with word_timestamps:true
+    language: 'auto'                  // default (use 'auto' for auto detect)
+    gen_file_txt: false,              // outputs .txt file
+    gen_file_subtitle: false,         // outputs .srt file
+    gen_file_vtt: false,              // outputs .vtt file
+    output_file_path: "~/Downloads",  // output file path (without file extension)
+    word_timestamps: true             // timestamp for every word
+    // timestamp_size: 0              // cannot use along with word_timestamps:true
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -57,16 +57,16 @@ import whisper from 'whisper-node';
 const filePath = "example/sample.wav"; // required
 
 const options = {
-  modelName: "base.en",               // default
-  // modelPath: "/custom/path/to/model.bin", // use model in a custom directory (cannot use along with 'modelName')
+  modelName: "base.en",                        // default
+  // modelPath: "/custom/path/to/model.bin",   // use model in a custom directory (cannot use along with 'modelName')
   whisperOptions: {
-    language: 'auto'                  // default (use 'auto' for auto detect)
-    gen_file_txt: false,              // outputs .txt file
-    gen_file_subtitle: false,         // outputs .srt file
-    gen_file_vtt: false,              // outputs .vtt file
-    output_file_path: "~/Downloads",  // output file path (without file extension)
-    word_timestamps: true             // timestamp for every word
-    // timestamp_size: 0              // cannot use along with word_timestamps:true
+    language: 'auto'                           // default (use 'auto' for auto detect)
+    gen_file_txt: false,                       // outputs .txt file
+    gen_file_subtitle: false,                  // outputs .srt file
+    gen_file_vtt: false,                       // outputs .vtt file
+    output_file_path: "~/Downloads/filename",  // output file path (without file extension)
+    word_timestamps: true                      // timestamp for every word
+    // timestamp_size: 0                       // cannot use along with word_timestamps:true
   }
 }
 

--- a/src/whisper.ts
+++ b/src/whisper.ts
@@ -47,6 +47,7 @@ const getFlags = (flags: IFlagTypes): string => {
   let s = "";
 
   // output files
+  if (flags.output_file_path) s += " -of " + flags.output_file_path;
   if (flags.gen_file_txt) s += " -otxt";
   if (flags.gen_file_subtitle) s += " -osrt";
   if (flags.gen_file_vtt) s += " -ovtt";
@@ -90,5 +91,6 @@ export type IFlagTypes = {
   "gen_file_vtt"?: boolean,
   "timestamp_size"?: number,
   "word_timestamps"?: boolean,
-  "language"?: string
+  "language"?: string,
+  "output_file_path"?: string,
 }

--- a/src/whisper.ts
+++ b/src/whisper.ts
@@ -92,5 +92,5 @@ export type IFlagTypes = {
   "timestamp_size"?: number,
   "word_timestamps"?: boolean,
   "language"?: string,
-  "output_file_path"?: string,
+  "output_file_path"?: string
 }


### PR DESCRIPTION
Adding this option provides more flexibility, enabling users to specify the output file path.
The [whisper.cpp ](https://github.com/ggerganov/whisper.cpp)repository includes the following flag:
```
-of FNAME, --output-file FNAME [       ] output file path (without file extension)
```